### PR TITLE
Parametrisierte Benchmarks

### DIFF
--- a/src/column.h
+++ b/src/column.h
@@ -25,17 +25,11 @@ protected:
     std::vector<T, allocator_t> m_attributeVector;
 };
 
-// fast random number generator
-inline unsigned long fastrandom(unsigned long &x, unsigned long &y, unsigned long &z) {
-    x ^= x << 16;
-    x ^= x >> 5;
-    x ^= x << 1;
-
-    unsigned long t = x;
-    x = y;
-    y = z;
-    z = t ^ x ^ y;
-    return z;
+template <class T>
+void doNotOptimizeAway(T&& datum) {
+  // Facebook style
+  // https://stackoverflow.com/questions/40122141/preventing-compiler-optimizations-while-benchmarking
+  asm volatile("" : "+r" (datum));
 }
 
 template<typename T>
@@ -45,5 +39,5 @@ void Column<T>::scan() const {
     {
         aggregate ^= attribute;
     }
-    std::cout << aggregate;
+    doNotOptimizeAway(aggregate);
 }

--- a/src/column.h
+++ b/src/column.h
@@ -7,7 +7,6 @@
 class AbstractColumn {
 public:
     virtual void scan() const = 0;
-    virtual void scanRandom() const = 0;
 };
 
 template <typename T>
@@ -19,12 +18,25 @@ public:
     typedef NumaAlloc<T> allocator_t;
 
     void scan() const override;
-    void scanRandom() const override;
+
     std::vector<T, allocator_t> &data() { return m_attributeVector; }
 
 protected:
     std::vector<T, allocator_t> m_attributeVector;
 };
+
+// fast random number generator
+inline unsigned long fastrandom(unsigned long &x, unsigned long &y, unsigned long &z) {
+    x ^= x << 16;
+    x ^= x >> 5;
+    x ^= x << 1;
+
+    unsigned long t = x;
+    x = y;
+    y = z;
+    z = t ^ x ^ y;
+    return z;
+}
 
 template<typename T>
 void Column<T>::scan() const {
@@ -32,16 +44,6 @@ void Column<T>::scan() const {
     for (auto &attribute : m_attributeVector)
     {
         aggregate ^= attribute;
-    }
-    std::cout << aggregate;
-}
-
-template<typename T>
-void Column<T>::scanRandom() const {
-    T aggregate = 0;
-    for (auto i = 0ul; i < m_attributeVector.size(); ++i)
-    {
-        aggregate ^= m_attributeVector[std::rand() % m_attributeVector.size()];
     }
     std::cout << aggregate;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ static void SetAffinity(int node) {
     }
 }
 
-static void BM_ColumnScan_1GB_Sequential(benchmark::State& state) {
+static void BM_ColumnScan_1M_Rows__LocalCols__RemoteCols(benchmark::State& state) {
     Table table;
 
     std::vector<std::size_t> columnIndices;
@@ -55,12 +55,12 @@ static void BM_ColumnScan_1GB_Sequential(benchmark::State& state) {
         }
     }
 }
-BENCHMARK(BM_ColumnScan_1GB_Sequential)
+BENCHMARK(BM_ColumnScan_1M_Rows__LocalCols__RemoteCols)
     ->RangeMultiplier(2)
     ->Ranges({
-        {1, 8}, // Local columns
-        {1, 8}  // Remote columns
+        {0, 8}, // Local columns
+        {0, 8}  // Remote columns
     })
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,54 +19,26 @@ static void SetAffinity(int node) {
     }
 }
 
-static void BM_ColumnScan_1GB_Sequential_Local(benchmark::State& state) {
-    Table table;
-
-    auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, 0);
-    auto columnIndex = table.addColumn(column);
-
-    SetAffinity(0);
-
-    while (state.KeepRunning())
-    {
-        table.column(columnIndex)->scan();
-    }
-}
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Local)->Unit(benchmark::kMillisecond);
-
-static void BM_ColumnScan_1GB_Sequential_Local_2_Columns(benchmark::State& state) {
-    Table table;
-
-    auto column1 = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, 0);
-    auto columnIndex1 = table.addColumn(column1);
-
-    auto column2 = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, 0);
-    auto columnIndex2 = table.addColumn(column2);
-
-    SetAffinity(0);
-
-    std::vector<std::size_t> columnIndices = {columnIndex1, columnIndex2};
-    auto cols = table.getColumns(columnIndices);
-
-    while (state.KeepRunning())
-    {
-        for (ColumnPtr &col : cols)
-        {
-            col->scan();
-        }
-    }
-}
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Local_2_Columns)->Unit(benchmark::kMillisecond);
-
-
-static void BM_ColumnScan_1GB_Sequential_Local_4_Columns(benchmark::State& state) {
+static void BM_ColumnScan_1GB_Sequential(benchmark::State& state) {
     Table table;
 
     std::vector<std::size_t> columnIndices;
 
-    for (uint i = 0; i < 4; ++i)
+    auto localColumns = state.range(0);
+    auto remoteColumns = state.range(1);
+
+    auto rows = 1 * 1000 * 1000UL;
+
+    for (auto i = 0; i < localColumns; ++i)
     {
-        auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, 0);
+        auto column = std::make_shared<Column<uint32_t>>(rows, 0);
+        auto columnIndex = table.addColumn(column);
+        columnIndices.push_back(columnIndex);
+    }
+
+    for (auto i = 0; i < remoteColumns; ++i)
+    {
+        auto column = std::make_shared<Column<uint32_t>>(rows, numa_max_node());
         auto columnIndex = table.addColumn(column);
         columnIndices.push_back(columnIndex);
     }
@@ -83,143 +55,12 @@ static void BM_ColumnScan_1GB_Sequential_Local_4_Columns(benchmark::State& state
         }
     }
 }
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Local_4_Columns)->Unit(benchmark::kMillisecond);
-
-static void BM_ColumnScan_1GB_Sequential_Local_8_Columns(benchmark::State& state) {
-    Table table;
-
-    std::vector<std::size_t> columnIndices;
-
-    for (uint i = 0; i < 8; ++i)
-    {
-        auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, 0);
-        auto columnIndex = table.addColumn(column);
-        columnIndices.push_back(columnIndex);
-    }
-
-    SetAffinity(0);
-
-    auto cols = table.getColumns(columnIndices);
-
-    while (state.KeepRunning())
-    {
-        for (ColumnPtr &col : cols)
-        {
-            col->scan();
-        }
-    }
-}
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Local_8_Columns)->Unit(benchmark::kMillisecond);
-
-static void BM_ColumnScan_1GB_Sequential_Remote(benchmark::State& state) {
-    Table table;
-
-    auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, numa_max_node());
-    auto columnIndex = table.addColumn(column);
-
-    SetAffinity(0);
-
-    while (state.KeepRunning())
-    {
-        table.column(columnIndex)->scan();
-    }
-}
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Remote)->Unit(benchmark::kMillisecond);
-
-static void BM_ColumnScan_1GB_Sequential_Remote_2_Columns(benchmark::State& state) {
-  Table table;
-
-  std::vector<std::size_t> columnIndices;
-
-  for (uint i = 0; i < 2; ++i)
-  {
-      auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, numa_max_node());
-      auto columnIndex = table.addColumn(column);
-      columnIndices.push_back(columnIndex);
-  }
-
-  SetAffinity(0);
-
-  auto cols = table.getColumns(columnIndices);
-
-  while (state.KeepRunning())
-  {
-      for (ColumnPtr &col : cols)
-      {
-          col->scan();
-      }
-  }
-}
-
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Remote_2_Columns)->Unit(benchmark::kMillisecond);
-
-static void BM_ColumnScan_1GB_Sequential_Remote_4_Columns(benchmark::State& state) {
-  Table table;
-
-  std::vector<std::size_t> columnIndices;
-
-  for (uint i = 0; i < 4; ++i)
-  {
-      auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, numa_max_node());
-      auto columnIndex = table.addColumn(column);
-      columnIndices.push_back(columnIndex);
-  }
-
-  SetAffinity(0);
-
-  auto cols = table.getColumns(columnIndices);
-
-  while (state.KeepRunning())
-  {
-      for (ColumnPtr &col : cols)
-      {
-          col->scan();
-      }
-  }
-}
-
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Remote_4_Columns)->Unit(benchmark::kMillisecond);
-
-static void BM_ColumnScan_1GB_Sequential_Remote_8_Columns(benchmark::State& state) {
-  Table table;
-
-  std::vector<std::size_t> columnIndices;
-
-  for (uint i = 0; i < 8; ++i)
-  {
-      auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, numa_max_node());
-      auto columnIndex = table.addColumn(column);
-      columnIndices.push_back(columnIndex);
-  }
-
-  SetAffinity(0);
-
-  auto cols = table.getColumns(columnIndices);
-
-  while (state.KeepRunning())
-  {
-      for (ColumnPtr &col : cols)
-      {
-          col->scan();
-      }
-  }
-}
-BENCHMARK(BM_ColumnScan_1GB_Sequential_Remote_8_Columns)->Unit(benchmark::kMillisecond);
-
-// static void BM_ColumnScan_1GB_Random_Local(benchmark::State& state) {
-//     Table table;
-//
-//     auto column = std::make_shared<Column<uint8_t>>(1 * 1000 * 1000 * 1000UL, 0);
-//     auto columnIndex = table.addColumn(column);
-//
-//     SetAffinity(0);
-//
-//     while (state.KeepRunning())
-//     {
-//         table.column(columnIndex)->scanRandom();
-//     }
-// }
-//BENCHMARK(BM_ColumnScan_1GB_Random_Local)->Unit(benchmark::kMillisecond);
-
+BENCHMARK(BM_ColumnScan_1GB_Sequential)
+    ->RangeMultiplier(2)
+    ->Ranges({
+        {1, 8}, // Local columns
+        {1, 8}  // Remote columns
+    })
+    ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Habe die Anzahl der lokalen und entfernten Spalten für den Column-Scan parametrisierbar gemacht.

Außerdem gibt es eine bessere Methode, das Wegoptimieren der aggregate Variablen zu verhindern.