### PR TITLE
Allocate hash table on remote NUMA nodes

### DIFF
--- a/src/column.h
+++ b/src/column.h
@@ -14,6 +14,7 @@ public:
     void scan() const;
     std::vector<T, allocator_t> &data() { return m_attributeVector; }
     T& valueAt(size_t index) { return m_attributeVector.at(index); }
+    int numaNode() const { return m_attributeVector.get_allocator().node; }
 
 protected:
     std::vector<T, allocator_t> m_attributeVector;

--- a/src/numaalloc.h
+++ b/src/numaalloc.h
@@ -9,13 +9,15 @@
 #include <numa.h>
 
 template <class T> class NumaAlloc {
-const int node;
 public:
+const int node;
 typedef T              value_type;
 typedef std::true_type propagate_on_container_move_assignment;
 typedef std::true_type is_always_equal;
 
 NumaAlloc(int node = 0) noexcept : node{node} {};
+template <typename TOther>
+NumaAlloc(const NumaAlloc<TOther> &other) noexcept : node{other.node} {};
 
 T* allocate (size_t num) {
     auto ret = numa_alloc_onnode(num * sizeof(T), node);


### PR DESCRIPTION
So I've changed the hash join implementation to allocate the hash table (i.e. `unordered_map`) on the second column's NUMA node (which is always remote in the benchmarks, except for the 'all-local' case).

After this initial change, results look as follows:
```
-------------------------------------------------------------------------------
Benchmark                                        Time           CPU Iterations
-------------------------------------------------------------------------------
BM_Join__LocalTables/2000                   711962 us     710298 us          1
BM_Join__LocalTables/20000                  959441 us     950938 us          1
BM_Join__LocalTables/200000                2135718 us    2111483 us          1
BM_Join__LocalTables/2000000              11937118 us   11792213 us          1
BM_Join__LocalTable_RemoteTable/2000        640466 us     637757 us          1
BM_Join__LocalTable_RemoteTable/20000       865821 us     860746 us          1
BM_Join__LocalTable_RemoteTable/200000     2327680 us    2313586 us          1
BM_Join__LocalTable_RemoteTable/2000000   14904921 us   14701757 us          1
BM_Join__SameRemoteTables/2000              644904 us     642521 us          1
BM_Join__SameRemoteTables/20000             854505 us     851762 us          1
BM_Join__SameRemoteTables/200000           2310492 us    2286080 us          1
BM_Join__SameRemoteTables/2000000         13302183 us   13113793 us          1
BM_Join__DifferentRemoteTables/2000         636037 us     634266 us          1
BM_Join__DifferentRemoteTables/20000        887082 us     880157 us          1
BM_Join__DifferentRemoteTables/200000      2360757 us    2332264 us          1
BM_Join__DifferentRemoteTables/2000000    13229928 us   13081547 us          1
```

So there's still no real difference. I've then experimented with two different hash map implementations from [Google's Sparsehash library](https://github.com/sparsehash/sparsehash): `sparse_hash_map`, which is very memory-efficient, and `dense_hash_map`, which is very fast and as a result has a different speed-memory tradeoff.

Results with `sparse_hash_map`:
```
-------------------------------------------------------------------------------
Benchmark                                        Time           CPU Iterations
-------------------------------------------------------------------------------
BM_Join__LocalTables/2000                   601297 us     597345 us          1
BM_Join__LocalTables/20000                  905674 us     898451 us          1
BM_Join__LocalTables/200000                1908350 us    1875810 us          1
BM_Join__LocalTables/2000000               6711790 us    6638307 us          1
BM_Join__LocalTable_RemoteTable/2000        511173 us     506175 us          1
BM_Join__LocalTable_RemoteTable/20000       781061 us     774776 us          1
BM_Join__LocalTable_RemoteTable/200000     1893969 us    1870778 us          1
BM_Join__LocalTable_RemoteTable/2000000    7560852 us    7431033 us          1
BM_Join__SameRemoteTables/2000              509396 us     508358 us          1
BM_Join__SameRemoteTables/20000             770509 us     768603 us          1
BM_Join__SameRemoteTables/200000           1934187 us    1896304 us          1
BM_Join__SameRemoteTables/2000000          7932057 us    7832287 us          1
BM_Join__DifferentRemoteTables/2000         514320 us     510481 us          1
BM_Join__DifferentRemoteTables/20000        779542 us     777135 us          1
BM_Join__DifferentRemoteTables/200000      1925274 us    1896337 us          1
BM_Join__DifferentRemoteTables/2000000     6959648 us    6889882 us          1
```

Still no difference, but here's the `dense_hash_map`:

```
-------------------------------------------------------------------------------
Benchmark                                        Time           CPU Iterations
-------------------------------------------------------------------------------
BM_Join__LocalTables/2000                   186913 us     185059 us          4
BM_Join__LocalTables/20000                  129331 us     128908 us          5
BM_Join__LocalTables/200000                 184345 us     183176 us          4
BM_Join__LocalTables/2000000                489950 us     486820 us          2
BM_Join__LocalTable_RemoteTable/2000        154215 us     153658 us          4
BM_Join__LocalTable_RemoteTable/20000       130298 us     129913 us          5
BM_Join__LocalTable_RemoteTable/200000      213418 us     212261 us          4
BM_Join__LocalTable_RemoteTable/2000000     564332 us     560075 us          1
BM_Join__SameRemoteTables/2000              152800 us     152267 us          4
BM_Join__SameRemoteTables/20000             131174 us     130615 us          5
BM_Join__SameRemoteTables/200000            189470 us     188887 us          3
BM_Join__SameRemoteTables/2000000           572281 us     565392 us          1
BM_Join__DifferentRemoteTables/2000         153561 us     152841 us          4
BM_Join__DifferentRemoteTables/20000        147798 us     147335 us          5
BM_Join__DifferentRemoteTables/200000       214939 us     213243 us          4
BM_Join__DifferentRemoteTables/2000000      556252 us     554050 us          1
```

Very fast! And there are actually slight differences for 200K/2M joined rows, so I'd suggest that we use this hash map for our benchmarks.
