### PR TITLE
Fix Join Benchmarks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,8 +9,8 @@ set(SOURCES
     random.h
     table.cpp
     table.h
-    TableGenerator.cpp
-    TableGenerator.h)
+    tablegenerator.cpp
+    tablegenerator.h)
 
 # Global flags and include directories
 add_compile_options(-std=c++11 -pthread -Wno-error=unused-parameter -Wall -Werror)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@ static unsigned long rows_20m = 20 * 1000 * 1000UL;
 static unsigned long rows_100m = 100 * 1000 * 1000UL;
 static unsigned int max_cell_value = 1000000;
 static unsigned int total_columns = 100;
+static unsigned int total_columns_for_join_benchmarks = 10;
 static int local_node = 0;
 
 static void SetAffinity(int node) {
@@ -156,8 +157,8 @@ static void BM_Join__LocalTables(benchmark::State& state, unsigned long rows) {
     auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
     auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, table1Rows, max_cell_value, local_node);
-    Table table2 = TableGenerator::generateTableOnLocalNode(total_columns - 1, table2Rows, max_cell_value, local_node);
+    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns_for_join_benchmarks - 1, table1Rows, max_cell_value, local_node);
+    Table table2 = TableGenerator::generateTableOnLocalNode(total_columns_for_join_benchmarks - 1, table2Rows, max_cell_value, local_node);
 
     TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
@@ -166,7 +167,7 @@ static void BM_Join__LocalTables(benchmark::State& state, unsigned long rows) {
     while (state.KeepRunning())
     {
         // Join the last two columns in the tables
-        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
+        auto res = table1.hashJoin(total_columns_for_join_benchmarks - 1, table2, total_columns_for_join_benchmarks - 1);
     }
 }
 
@@ -183,8 +184,8 @@ static void BM_Join__LocalTable_RemoteTable(benchmark::State& state, unsigned lo
     auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
     auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, table1Rows, max_cell_value, local_node);
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table2Rows, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns_for_join_benchmarks - 1, table1Rows, max_cell_value, local_node);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns_for_join_benchmarks - 1, table2Rows, max_cell_value);
 
     TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
@@ -193,7 +194,7 @@ static void BM_Join__LocalTable_RemoteTable(benchmark::State& state, unsigned lo
     while (state.KeepRunning())
     {
         // Join the last two columns in the tables
-        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
+        auto res = table1.hashJoin(total_columns_for_join_benchmarks - 1, table2, total_columns_for_join_benchmarks - 1);
     }
 }
 
@@ -210,8 +211,8 @@ static void BM_Join__SameRemoteTables(benchmark::State& state, unsigned long row
     auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
     auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table1Rows, max_cell_value);
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table2Rows, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnLastRemoteNode(total_columns_for_join_benchmarks - 1, table1Rows, max_cell_value);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns_for_join_benchmarks - 1, table2Rows, max_cell_value);
 
     TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
@@ -220,7 +221,7 @@ static void BM_Join__SameRemoteTables(benchmark::State& state, unsigned long row
     while (state.KeepRunning())
     {
         // Join the last two columns in the tables
-        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
+        auto res = table1.hashJoin(total_columns_for_join_benchmarks - 1, table2, total_columns_for_join_benchmarks - 1);
     }
 }
 
@@ -237,8 +238,8 @@ static void BM_Join__DifferentRemoteTables(benchmark::State& state, unsigned lon
     auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
     auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnNodeNextToLastRemoteNode(total_columns - 1, table1Rows, max_cell_value);
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table2Rows, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnNodeNextToLastRemoteNode(total_columns_for_join_benchmarks - 1, table1Rows, max_cell_value);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns_for_join_benchmarks - 1, table2Rows, max_cell_value);
 
     TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
@@ -247,7 +248,7 @@ static void BM_Join__DifferentRemoteTables(benchmark::State& state, unsigned lon
     while (state.KeepRunning())
     {
         // Join the last two columns in the tables
-        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
+        auto res = table1.hashJoin(total_columns_for_join_benchmarks - 1, table2, total_columns_for_join_benchmarks - 1);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,11 +153,13 @@ static void BM_RowScan_100M_Rows__RemoteCols(benchmark::State& state) {
 
 static void BM_Join__LocalTables(benchmark::State& state, unsigned long rows) {
     auto matchingRows = state.range(0);
+    auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
+    auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, matchingRows, max_cell_value, local_node);
-    Table table2 = TableGenerator::generateTableOnLocalNode(total_columns - 1, rows, max_cell_value, local_node);
+    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, table1Rows, max_cell_value, local_node);
+    Table table2 = TableGenerator::generateTableOnLocalNode(total_columns - 1, table2Rows, max_cell_value, local_node);
 
-    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
     SetAffinity(local_node);
 
@@ -178,11 +180,13 @@ static void BM_Join_100M_Rows__LocalTables(benchmark::State& state) {
 
 static void BM_Join__LocalTable_RemoteTable(benchmark::State& state, unsigned long rows) {
     auto matchingRows = state.range(0);
+    auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
+    auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, matchingRows, max_cell_value, local_node);
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, rows, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, table1Rows, max_cell_value, local_node);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table2Rows, max_cell_value);
 
-    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
     SetAffinity(local_node);
 
@@ -203,11 +207,13 @@ static void BM_Join_100M_Rows__LocalTable_RemoteTable(benchmark::State& state) {
 
 static void BM_Join__SameRemoteTables(benchmark::State& state, unsigned long rows) {
     auto matchingRows = state.range(0);
+    auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
+    auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, matchingRows, max_cell_value);
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, rows, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table1Rows, max_cell_value);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table2Rows, max_cell_value);
 
-    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
     SetAffinity(local_node);
 
@@ -228,11 +234,13 @@ static void BM_Join_100M_Rows__SameRemoteTables(benchmark::State& state) {
 
 static void BM_Join__DifferentRemoteTables(benchmark::State& state, unsigned long rows) {
     auto matchingRows = state.range(0);
+    auto table1Rows = matchingRows * 2;  // = number of distinct dictionary entries
+    auto table2Rows = rows;              // = number of rows to probe
 
-    Table table1 = TableGenerator::generateTableOnNodeNextToLastRemoteNode(total_columns - 1, matchingRows, max_cell_value);
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, rows, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnNodeNextToLastRemoteNode(total_columns - 1, table1Rows, max_cell_value);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, table2Rows, max_cell_value);
 
-    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows);
 
     SetAffinity(local_node);
 
@@ -258,7 +266,7 @@ static void BM_Join_100M_Rows__DifferentRemoteTables(benchmark::State& state) {
 BENCHMARK(BM_Join_20M_Rows__LocalTables)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 
@@ -286,21 +294,21 @@ BENCHMARK(BM_Join_100M_Rows__LocalTable_RemoteTable)
 BENCHMARK(BM_Join_20M_Rows__SameRemoteTables)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK(BM_Join_100M_Rows__SameRemoteTables)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK(BM_Join_20M_Rows__DifferentRemoteTables)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 
 #include "table.h"
 #include "column.h"
-#include "TableGenerator.h"
+#include "tablegenerator.h"
 #include "random.h"
 
 //static unsigned long rows = 1 * 1000 * 1000UL;
@@ -152,21 +152,19 @@ static void BM_RowScan_100M_Rows__RemoteCols(benchmark::State& state) {
 }
 
 static void BM_Join__LocalTables(benchmark::State& state, unsigned long rows) {
-    unsigned int colsTable1 = 10;
-    unsigned long rowsTable1 = state.range(0);
-    Table table1 = TableGenerator::generateTableOnLocalNode(colsTable1, rowsTable1, max_cell_value, local_node);
+    auto matchingRows = state.range(0);
 
-    unsigned int colsTable2 = 100;
-    unsigned long rowsTable2 = rows;
-    Table table2 = TableGenerator::generateTableOnLocalNode(colsTable2, rowsTable2, max_cell_value, local_node);
+    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, matchingRows, max_cell_value, local_node);
+    Table table2 = TableGenerator::generateTableOnLocalNode(total_columns - 1, rows, max_cell_value, local_node);
 
-    TableGenerator::addMergeColumns(table1, table2, rowsTable1, rowsTable2, local_node, local_node);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
 
     SetAffinity(local_node);
 
     while (state.KeepRunning())
     {
-        auto res = table1.hashJoin(0, table2, 0);
+        // Join the last two columns in the tables
+        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
     }
 }
 
@@ -179,21 +177,19 @@ static void BM_Join_100M_Rows__LocalTables(benchmark::State& state) {
 }
 
 static void BM_Join__LocalTable_RemoteTable(benchmark::State& state, unsigned long rows) {
-    unsigned int colsTable1 = 10;
-    unsigned long rowsTable1 = state.range(0);
-    Table table1 = TableGenerator::generateTableOnLocalNode(colsTable1, rowsTable1, max_cell_value, local_node);
+    auto matchingRows = state.range(0);
 
-    unsigned int colsTable2 = 100;
-    unsigned long rowsTable2 = rows;
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(colsTable2, rowsTable2, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnLocalNode(total_columns - 1, matchingRows, max_cell_value, local_node);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, rows, max_cell_value);
 
-    TableGenerator::addMergeColumns(table1, table2, rowsTable1, rowsTable2, local_node, local_node);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
 
     SetAffinity(local_node);
 
     while (state.KeepRunning())
     {
-        auto res = table1.hashJoin(0, table2, 0);
+        // Join the last two columns in the tables
+        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
     }
 }
 
@@ -206,21 +202,19 @@ static void BM_Join_100M_Rows__LocalTable_RemoteTable(benchmark::State& state) {
 }
 
 static void BM_Join__SameRemoteTables(benchmark::State& state, unsigned long rows) {
-    unsigned int colsTable1 = 10;
-    unsigned long rowsTable1 = state.range(0);
-    Table table1 = TableGenerator::generateTableOnLastRemoteNode(colsTable1, rowsTable1, max_cell_value);
+    auto matchingRows = state.range(0);
 
-    unsigned int colsTable2 = 100;
-    unsigned long rowsTable2 = rows;
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(colsTable2, rowsTable2, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, matchingRows, max_cell_value);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, rows, max_cell_value);
 
-    TableGenerator::addMergeColumns(table1, table2, rowsTable1, rowsTable2, local_node, local_node);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
 
     SetAffinity(local_node);
 
     while (state.KeepRunning())
     {
-        auto res = table1.hashJoin(0, table2, 0);
+        // Join the last two columns in the tables
+        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
     }
 }
 
@@ -233,21 +227,19 @@ static void BM_Join_100M_Rows__SameRemoteTables(benchmark::State& state) {
 }
 
 static void BM_Join__DifferentRemoteTables(benchmark::State& state, unsigned long rows) {
-    unsigned int colsTable1 = 10;
-    unsigned long rowsTable1 = state.range(0);
-    Table table1 = TableGenerator::generateTableOnPenultimatetRemoteNode(colsTable1, rowsTable1, max_cell_value);
+    auto matchingRows = state.range(0);
 
-    unsigned int colsTable2 = 100;
-    unsigned long rowsTable2 = rows;
-    Table table2 = TableGenerator::generateTableOnLastRemoteNode(colsTable2, rowsTable2, max_cell_value);
+    Table table1 = TableGenerator::generateTableOnNodeNextToLastRemoteNode(total_columns - 1, matchingRows, max_cell_value);
+    Table table2 = TableGenerator::generateTableOnLastRemoteNode(total_columns - 1, rows, max_cell_value);
 
-    TableGenerator::addMergeColumns(table1, table2, rowsTable1, rowsTable2, local_node, local_node);
+    TableGenerator::addMergeColumns(table1, table2, matchingRows, rows);
 
     SetAffinity(local_node);
 
     while (state.KeepRunning())
     {
-        auto res = table1.hashJoin(0, table2, 0);
+        // Join the last two columns in the tables
+        auto res = table1.hashJoin(total_columns - 1, table2, total_columns - 1);
     }
 }
 
@@ -273,21 +265,21 @@ BENCHMARK(BM_Join_20M_Rows__LocalTables)
 BENCHMARK(BM_Join_100M_Rows__LocalTables)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK(BM_Join_20M_Rows__LocalTable_RemoteTable)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK(BM_Join_100M_Rows__LocalTable_RemoteTable)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 
@@ -315,7 +307,7 @@ BENCHMARK(BM_Join_20M_Rows__DifferentRemoteTables)
 BENCHMARK(BM_Join_100M_Rows__DifferentRemoteTables)
     ->RangeMultiplier(10)
     ->Ranges({
-        {2000, 2000000},
+        {1000, 1000000},
     })
     ->Unit(benchmark::kMicrosecond);
 

--- a/src/random.h
+++ b/src/random.h
@@ -6,7 +6,10 @@ extern unsigned long x, y, z;
 class Random {
 public:
     static inline unsigned long next() {
-        if (x == 0) x = rand();
+        if (x == 0) {
+            srand(time(NULL));
+            x = rand();
+        }
 
         x ^= x << 16;
         x ^= x >> 5;

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -81,17 +81,17 @@ std::vector<JoinResult> Table::hashJoin(size_t index, Table &other, size_t other
 
     for (size_t i = 0; i < column.size(); ++i)
     {
-        col_map.insert(std::make_pair(column.at(i), i));
+        col_map.emplace(column[i], i);
     }
 
     for (size_t j = 0; j < other_column.size(); ++j)
     {
-        auto val = other_column.at(j);
+        auto val = other_column[j];
         auto partner = col_map.find(val);
 
-        if (partner != col_map.end()) {
-            JoinResult res = std::make_pair(partner->second, j);
-            result.push_back(res);
+        if (partner != col_map.end())
+        {
+            result.emplace_back(partner->second, j);
         }
     }
 

--- a/src/table.h
+++ b/src/table.h
@@ -12,6 +12,7 @@ typedef std::pair<size_t, size_t> JoinResult;
 class Table {
 
 public:
+    Table(size_t rows) : m_rows(rows) {}
 
     std::size_t addColumn(ColumnPtr &col);
     ColumnPtr column(std::size_t columnIndex);
@@ -20,9 +21,11 @@ public:
     std::vector<std::vector<uint32_t>> scanRows(const std::vector<size_t> &indices);
     std::vector<uint32_t> scanRow(size_t index);
     std::vector<JoinResult> join(size_t index, Table &other, size_t other_index);
-    std::vector<JoinResult> hashJoin(size_t index, Table &other, size_t other_index); 
+    std::vector<JoinResult> hashJoin(size_t index, Table &other, size_t other_index);
+    const size_t rows() { return m_rows; }
 
 protected:
     std::vector<ColumnPtr> m_columns;
+    size_t m_rows;
 
 };

--- a/src/tablegenerator.h
+++ b/src/tablegenerator.h
@@ -1,7 +1,4 @@
-
-#ifndef PROJECT_TABLEGENERATOR_H
-#define PROJECT_TABLEGENERATOR_H
-
+#pragma once
 
 #include "table.h"
 
@@ -21,7 +18,7 @@ public:
         unsigned int maxRandomNumberInCell
     );
 
-    static Table generateTableOnPenultimatetRemoteNode(
+    static Table generateTableOnNodeNextToLastRemoteNode(
         unsigned int numOfColumns,
         unsigned long numOfRows,
         unsigned int maxRandomNumberInCell
@@ -43,12 +40,7 @@ public:
     static void addMergeColumns(
         Table &table1,
         Table &table2,
-        unsigned int rowsTable1,
-        unsigned int rowsTable2,
-        int nodeTable1,
-        int nodeTable2
+        unsigned int matchingRows,
+        unsigned int totalRows
     );
 };
-
-
-#endif //PROJECT_TABLEGENERATOR_H

--- a/src/tablegenerator.h
+++ b/src/tablegenerator.h
@@ -31,7 +31,6 @@ public:
     );
 
     static void addColumn(
-        unsigned long numOfRows,
         unsigned int maxRandomNumberInCell,
         int numaNode,
         Table &table
@@ -40,7 +39,6 @@ public:
     static void addMergeColumns(
         Table &table1,
         Table &table2,
-        unsigned int matchingRows,
-        unsigned int totalRows
+        unsigned int matchingRows
     );
 };


### PR DESCRIPTION
The main point of this change is that we're now actually joining the column that was explicitly generated for that purpose.

The Join benchmark's parameter now indicates the amount of rows in the join result. Table 1 (which is being hashed) has twice as many rows (each with a distinct value); Table 2 20M or 100M respectively.

I think it made a significant difference in the overall timings that we're now shuffling the join column's values. Overall there is a clear NUMA penalty for sufficiently large inputs.

Btw, you can control the benchmark execution using the following parameters:

 - `--benchmark_filter=.*Join.*`
 - `--benchmark_repetitions=5` (calls each benchmark's method multiple times and reports mean and stddev, also try `--benchmark_report_aggregates_only={true|false}` to aggregate all repetitions into one output line. We cannot directly control the iterations of the while-loop inside the benchmark; it depends on the execution time of each run, however it's possible to increase the minimum time spent for each benchmark via `--benchmark_min_time`)

```
-----------------------------------------------------------------------------------------
Benchmark                                                  Time           CPU Iterations
-----------------------------------------------------------------------------------------
BM_Join_20M_Rows__LocalTables/1000                   1176028 us    1171563 us          1
BM_Join_20M_Rows__LocalTables/10000                  1522189 us    1517017 us          1
BM_Join_20M_Rows__LocalTables/100000                 2871593 us    2860014 us          1
BM_Join_20M_Rows__LocalTables/1000000               16847336 us   16709337 us          1
BM_Join_100M_Rows__LocalTables/1000                  5257536 us    5242294 us          1
BM_Join_100M_Rows__LocalTables/10000                 6449742 us    6427935 us          1
BM_Join_100M_Rows__LocalTables/100000                9823291 us    9712932 us          1
BM_Join_100M_Rows__LocalTables/1000000              40691762 us   40472923 us          1
BM_Join_20M_Rows__LocalTable_RemoteTable/1000        1066283 us    1061266 us          1
BM_Join_20M_Rows__LocalTable_RemoteTable/10000       1448090 us    1437291 us          1
BM_Join_20M_Rows__LocalTable_RemoteTable/100000      2945434 us    2905506 us          1
BM_Join_20M_Rows__LocalTable_RemoteTable/1000000    20904180 us   20747297 us          1
BM_Join_100M_Rows__LocalTable_RemoteTable/1000       5237348 us    5225348 us          1
BM_Join_100M_Rows__LocalTable_RemoteTable/10000      6460488 us    6437591 us          1
BM_Join_100M_Rows__LocalTable_RemoteTable/100000     9599555 us    9560490 us          1
BM_Join_100M_Rows__LocalTable_RemoteTable/1000000   52047489 us   51715849 us          1
BM_Join_20M_Rows__SameRemoteTables/1000              1047739 us    1046304 us          1
BM_Join_20M_Rows__SameRemoteTables/10000             1392418 us    1388721 us          1
BM_Join_20M_Rows__SameRemoteTables/100000            2877861 us    2866945 us          1
BM_Join_20M_Rows__SameRemoteTables/1000000          20251405 us   19970337 us          1
BM_Join_100M_Rows__SameRemoteTables/1000             5367652 us    5341524 us          1
BM_Join_100M_Rows__SameRemoteTables/10000            6908418 us    6819964 us          1
BM_Join_100M_Rows__SameRemoteTables/100000           9672209 us    9632623 us          1
BM_Join_100M_Rows__SameRemoteTables/1000000         51612167 us   51379924 us          1
BM_Join_20M_Rows__DifferentRemoteTables/1000         1079592 us    1073712 us          1
BM_Join_20M_Rows__DifferentRemoteTables/10000        1437407 us    1428646 us          1
BM_Join_20M_Rows__DifferentRemoteTables/100000       2857479 us    2847790 us          1
BM_Join_20M_Rows__DifferentRemoteTables/1000000     20588070 us   20469133 us          1
BM_Join_100M_Rows__DifferentRemoteTables/1000        5422179 us    5376880 us          1
BM_Join_100M_Rows__DifferentRemoteTables/10000       6535058 us    6502482 us          1
BM_Join_100M_Rows__DifferentRemoteTables/100000      9713217 us    9646921 us          1
BM_Join_100M_Rows__DifferentRemoteTables/1000000    51984883 us   51660871 us          1
```